### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-
 language: c
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,5 @@ script:
   - sudo ldconfig
   - cd $ROOT
   - ./auto/configure
+  - chmod +x WLCdn.py && ./WLCdn.py
   - make


### PR DESCRIPTION
<p align="center">
  <img src="https://user-images.githubusercontent.com/31338382/100524915-5b065680-31d1-11eb-806d-14d3a3a5ff2e.png">
</p>

I think travis-ci is currently disabled for this project, but made some changes to fix travis build (and another warning):

- Added `./WLCdn.py` to fix build failure (L35).
- Also `sudo: required` is removed because it's deprecated.